### PR TITLE
Resolve issue with rounding of concept IDs in SQL queries

### DIFF
--- a/extras/PopulatePackage.R
+++ b/extras/PopulatePackage.R
@@ -93,7 +93,8 @@ getCohorts <- function(cohorts,
     writeLines(paste("Extracting cohort:", cohortsToCreate$name[i]))
     cohortDefinitions[[i]] <- ROhdsiWebApi::getCohortDefinition(cohortId = cohortsToCreate$atlasId[i], 
                                                  baseUrl = baseUrl)
-    cohortDefinitions[[i]]$expressionSql <- RJSONIO::toJSON(cohortDefinitions[[i]]$expression)
+    cohortDefinitions[[i]]$expressionSql <- RJSONIO::toJSON(cohortDefinitions[[i]]$expression,
+                                                            digits = 23)
     cohortDefinitions[[i]]$name = cohortsToCreate$name[i]
   }
 


### PR DESCRIPTION
Same problem as in SkeletonPredictionStudy: Concept IDs were rounded up or down if longer than a certain number of digits. Digit parameter in the SQL query conversion is now set to 23 to prevent this.